### PR TITLE
Improve logic for overlapping sector names.

### DIFF
--- a/src/components/SectorPolygons.tsx
+++ b/src/components/SectorPolygons.tsx
@@ -28,6 +28,17 @@ const sectorHighlightPaint: FillPaint = {
   'fill-opacity': 0.4,
 };
 
+const sectorNameslayout: SymbolLayout = {
+  'text-field': ['get', 'title'],
+  'text-allow-overlap': true,
+  'text-radial-offset': 0.3,
+  'text-variable-anchor': ['center', 'left', 'right', 'top', 'bottom', 'top-left', 'top-right', 'bottom-left', 'bottom-right'],
+  'text-font': [
+    'Open Sans Bold',
+  ],
+  'text-size': 14,
+};
+
 export default observer(function SectorPolygons(/* properties */) {
   const { highestBound, lowestBound } = cwpStore.altitudeFilter;
   const { showSectorLabels, showClickedSector, clickedSectorId } = cwpStore;
@@ -40,13 +51,8 @@ export default observer(function SectorPolygons(/* properties */) {
       && area.sectorArea?.length > 0,
     );
   const sectorNamesText: SymbolLayout = {
+    ...sectorNameslayout,
     visibility: showSectorLabels ? 'visible' : 'none',
-    'text-field': ['get', 'title'],
-    'text-allow-overlap': true,
-    'text-font': [
-      'Open Sans Bold',
-    ],
-    'text-size': 14,
   };
   const getSectorColor = (bottom: number, top: number): string => {
     if (top > highestBound) {


### PR DESCRIPTION
Fix #81

## Before
![image](https://user-images.githubusercontent.com/45740/183039599-3712a8b2-03b3-482a-b9bb-d3e47b0fa995.png)

## After
![image](https://user-images.githubusercontent.com/45740/183039629-d7ed8f8d-1c87-433a-85c1-cb52e9e380a7.png)
