### PR TITLE
Some refactoring and improvements.

### DIFF
--- a/src/components/AircraftLevelPopup.tsx
+++ b/src/components/AircraftLevelPopup.tsx
@@ -7,6 +7,7 @@ import {
   changeFlightLevelOfAircraft,
   handlePublishPromise,
   persistACCFlightLevel,
+  persistAssignedFlightLevel,
   persistNextSectorFlightSpeed,
 } from '../mqtt/publishers';
 import { configurationStore, cwpStore } from '../state';
@@ -97,6 +98,9 @@ export default observer(function AircraftLevelPopup(properties: { aircraft: Airc
       setAssignedFlightLevel(stringFlightLevel);
       handlePublishPromise(
         changeFlightLevelOfAircraft(controlledBy, assignedFlightId, stringFlightLevel),
+      );
+      handlePublishPromise(
+        persistAssignedFlightLevel(assignedFlightId, stringFlightLevel),
       );
     }
     close();

--- a/src/components/AircraftLevelPopup.tsx
+++ b/src/components/AircraftLevelPopup.tsx
@@ -8,7 +8,8 @@ import {
   handlePublishPromise,
   persistACCFlightLevel,
   persistAssignedFlightLevel,
-  persistNextSectorFlightSpeed,
+  persistLocalAssignedFlightLevel,
+  persistNextSectorFlightLevel,
 } from '../mqtt/publishers';
 import { configurationStore, cwpStore } from '../state';
 import type AircraftModel from '../model/AircraftModel';
@@ -84,7 +85,7 @@ export default observer(function AircraftLevelPopup(properties: { aircraft: Airc
       cwpStore.showNSFL(false);
       setNextSectorFL(stringFlightLevel);
       handlePublishPromise(
-        persistNextSectorFlightSpeed(assignedFlightId, stringFlightLevel),
+        persistNextSectorFlightLevel(assignedFlightId, stringFlightLevel),
       );
     } else if (cwpStore.flightLevelNextAccActivated) {
       cwpStore.showFlACC(false);
@@ -94,6 +95,9 @@ export default observer(function AircraftLevelPopup(properties: { aircraft: Airc
       );
     } else if (!cwpStore.pseudoPilot) {
       setLocalAssignedFlightLevel(stringFlightLevel);
+      handlePublishPromise(
+        persistLocalAssignedFlightLevel(assignedFlightId, stringFlightLevel),
+      );
     } else {
       setAssignedFlightLevel(stringFlightLevel);
       handlePublishPromise(
@@ -126,7 +130,8 @@ export default observer(function AircraftLevelPopup(properties: { aircraft: Airc
           <Button onClick={(): void => FlightLevelChange('up')} size="sm" variant="secondary" className="arrow-button justify-content-center">&#11165;</Button>
           <input className="level-range" type="range"
                 value={flightLevel}
-                onChange={(event): void => setFlightLevel(Number.parseInt(event.target.value, 10))}
+                onChange={(event): void => setFlightLevel(
+                  Number.parseInt(event.target.value, 10) || 0)}
                 step={sliderStep} min={flightLevelMin} max={flightLevelMax}
               />
           <Button onClick={(): void => FlightLevelChange('down')} size="sm" variant="secondary" className="arrow-button justify-content-center">&#11167;</Button>

--- a/src/components/AircraftPopup.tsx
+++ b/src/components/AircraftPopup.tsx
@@ -46,10 +46,19 @@ export default observer(function AircraftPopup(properties: {
   }
   const showAllFlightLabels = cwpStore.showFlightLabels;
 
+  const bounds = configurationStore.extendedEdgesBounds;
+
   const shouldShow = cwpStore.aircraftsWithManuallyOpenedPopup.has(aircraftId)
     || (altitude >= lowestBound && altitude <= highestBound
       && showAllFlightLabels
-      && !cwpStore.aircraftsWithManuallyClosedPopup.has(aircraftId));
+      && !cwpStore.aircraftsWithManuallyClosedPopup.has(aircraftId)
+      // Airplanes far the sectors are not shown by default
+      && bounds !== undefined
+      && latitude >= bounds.minLat
+      && latitude <= bounds.maxLat
+      && longitude >= bounds.minLon
+      && longitude <= bounds.maxLon
+    );
 
   const { current } = useMap();
 

--- a/src/components/AircraftPopupContent.tsx
+++ b/src/components/AircraftPopupContent.tsx
@@ -37,7 +37,7 @@ const CallSign = observer(({ aircraft, colSpan }: SubContentProperties): JSX.Ele
   return (<td onClick={setController} colSpan={colSpan}>{callSign}</td>);
 });
 
-const Altitude = observer(({ aircraft }: SubContentProperties): JSX.Element => {
+export const Altitude = observer(({ aircraft }: SubContentProperties): JSX.Element => {
   const onClick = (): void => {
     if (isDragging()) return;
     cwpStore.openLevelPopupForAircraft(aircraft.aircraftId);
@@ -76,7 +76,7 @@ const NextFix = observer(({ aircraft }: SubContentProperties): JSX.Element => {
     </td>);
 });
 
-const NextSectorFL = observer(({ aircraft }: SubContentProperties): JSX.Element => {
+export const NextSectorFL = observer(({ aircraft }: SubContentProperties): JSX.Element => {
   const openNSFLPopup = (): void => {
     if (isDragging()) return;
     cwpStore.showNSFL(true);
@@ -90,7 +90,7 @@ const NextSectorFL = observer(({ aircraft }: SubContentProperties): JSX.Element 
   );
 });
 
-const NextSectorController = observer(({ aircraft }: SubContentProperties): JSX.Element => {
+export const NextSectorController = observer(({ aircraft }: SubContentProperties): JSX.Element => {
   const onClick = (): void => {
     if (isDragging()) return;
     cwpStore.openNextSectorPopupForAircraft(aircraft.aircraftId);
@@ -100,13 +100,14 @@ const NextSectorController = observer(({ aircraft }: SubContentProperties): JSX.
   </td>);
 });
 
-const LocalAssignedFlightLevel = observer(({ aircraft }: SubContentProperties): JSX.Element => (
+export const LocalAssignedFlightLevel = observer(({ aircraft }: SubContentProperties,
+): JSX.Element => (
   <td>
     {aircraft.localAssignedFlightLevel}
   </td>
 ));
 
-const NextACCFlightLevel = observer(({ aircraft }: SubContentProperties): JSX.Element => {
+export const NextACCFlightLevel = observer(({ aircraft }: SubContentProperties): JSX.Element => {
   const openNextACCPopup = (): void => {
     if (isDragging()) return;
     cwpStore.showFlACC(true);

--- a/src/components/AircraftPopupPseudoContent.tsx
+++ b/src/components/AircraftPopupPseudoContent.tsx
@@ -5,6 +5,9 @@ import React from 'react';
 import { isDragging } from '../draggableState';
 import { acceptFlight, handlePublishPromise } from '../mqtt/publishers';
 import { aircraftStore, configurationStore, cwpStore } from '../state';
+import {
+  Altitude, LocalAssignedFlightLevel, NextACCFlightLevel, NextSectorController, NextSectorFL,
+} from './AircraftPopupContent';
 import type AircraftModel from '../model/AircraftModel';
 
 type SubContentProperties = {
@@ -33,16 +36,6 @@ const Bearing = observer(({ aircraft }: SubContentProperties): JSX.Element => {
 
   return (<td onClick={onClick}>
     {Math.round(aircraft.lastKnownBearing)}
-  </td>);
-});
-
-const Altitude = observer(({ aircraft }: SubContentProperties): JSX.Element => {
-  const onClick = (): void => {
-    if (isDragging()) return;
-    cwpStore.openLevelPopupForAircraft(aircraft.aircraftId);
-  };
-  return (<td onClick={onClick}>
-    {Number.parseFloat((aircraft.lastKnownAltitude).toFixed(0))}
   </td>);
 });
 
@@ -102,20 +95,6 @@ const AssignedFlightLevel = observer(({ aircraft }: SubContentProperties): JSX.E
   </td>);
 });
 
-const NextSectorFL = observer(({ aircraft }: SubContentProperties): JSX.Element => {
-  const openNSFLPopup = (): void => {
-    if (isDragging()) return;
-    cwpStore.showNSFL(true);
-    cwpStore.openLevelPopupForAircraft(aircraft.aircraftId);
-  };
-  return (
-    <td
-        onClick={openNSFLPopup}>
-      {aircraft.nextSectorFL}
-    </td>
-  );
-});
-
 const AssignedSpeed = observer(({ aircraft }: SubContentProperties): JSX.Element => (
   <td>{
     aircraft.assignedSpeed === -1 || aircraft.assignedSpeed === undefined
@@ -123,34 +102,6 @@ const AssignedSpeed = observer(({ aircraft }: SubContentProperties): JSX.Element
       }
   </td>
 ));
-
-const NextSectorController = observer(({ aircraft }: SubContentProperties): JSX.Element => {
-  const onClick = (): void => {
-    if (isDragging()) return;
-    cwpStore.openNextSectorPopupForAircraft(aircraft.aircraftId);
-  };
-  return (<td onClick={onClick}>
-    {aircraft.nextSectorController}
-  </td>);
-});
-
-const LocalAssignedFlightLevel = observer(({ aircraft }: SubContentProperties): JSX.Element => (
-  <td>
-    {aircraft.localAssignedFlightLevel}
-  </td>
-));
-
-const NextACCFlightLevel = observer(({ aircraft }: SubContentProperties): JSX.Element => {
-  const openNextACCPopup = (): void => {
-    if (isDragging()) return;
-    cwpStore.showFlACC(true);
-    cwpStore.openLevelPopupForAircraft(aircraft.aircraftId);
-  };
-
-  return (<td onClick={openNextACCPopup}>
-    {aircraft.nextACCFL}
-  </td>);
-});
 
 export default observer(function AircraftPopupPseudoContent(
   { aircraft }: SubContentProperties,

--- a/src/components/AircraftPopupPseudoContent.tsx
+++ b/src/components/AircraftPopupPseudoContent.tsx
@@ -1,114 +1,187 @@
 import { observer } from 'mobx-react-lite';
 // eslint-disable-next-line @typescript-eslint/consistent-type-imports
 import React from 'react';
-import { Col, Container, Row } from 'react-bootstrap';
 
 import { isDragging } from '../draggableState';
 import { acceptFlight, handlePublishPromise } from '../mqtt/publishers';
 import { aircraftStore, configurationStore, cwpStore } from '../state';
 import type AircraftModel from '../model/AircraftModel';
 
-export default observer(function AircraftPopupPseudoContent(properties: {
+type SubContentProperties = {
   aircraft: AircraftModel;
-}) {
-  const { aircraft } = properties;
+  colSpan?: number;
+};
 
-  // eslint-disable-next-line @typescript-eslint/unbound-method
-  const {
-    aircraftId,
-    assignedFlightId,
-    lastKnownAltitude: altitude,
-    lastKnownBearing: bearing,
-    lastKnownSpeed: speed,
-    callSign,
-    speedAndWakeTurbulenceLabel,
-    controlledBy,
-    nextSectorController,
-    nextFix,
-    assignedFlightLevel,
-    setAssignedFlightLevel,
-    assignedBearing,
-    setAssignedBearing,
-    assignedSpeed,
-    setAssignedSpeed,
-    localAssignedFlightLevel,
-    nextSectorFL,
-    setNextSectorFL,
-    nextACCFL,
-    setNextACCFL,
-  } = aircraft;
-
-  if (assignedFlightLevel === altitude.toFixed(0)) {
-    setAssignedFlightLevel('FL.S');
-  }
-  if (assignedBearing === bearing) {
-    setAssignedBearing(-1);
-  }
-  if (assignedSpeed === speed) {
-    setAssignedSpeed(-1);
-  }
-  if (nextSectorFL === altitude.toFixed(0)) {
-    setNextSectorFL('NSFL');
-  }
-  if (nextACCFL === altitude.toFixed(0)) {
-    setNextACCFL('COO');
-  }
-
+const CallSign = observer(({ aircraft, colSpan }: SubContentProperties): JSX.Element => {
+  const { callSign } = aircraft;
   const setController = (): void => {
-    // TODO #97: Implement setController shared across browsers, usinq MQTT
+    if (isDragging()) return;
+    const { aircraftId, controlledBy, assignedFlightId } = aircraft;
     aircraftStore.aircrafts.get(aircraftId)?.setController(configurationStore.currentCWP);
     handlePublishPromise(
       acceptFlight(controlledBy, configurationStore.currentCWP, assignedFlightId),
     );
   };
+  return (<td onClick={setController} colSpan={colSpan}>{callSign}</td>);
+});
+
+const Bearing = observer(({ aircraft }: SubContentProperties): JSX.Element => {
+  const onClick = (): void => {
+    if (isDragging()) return;
+    cwpStore.openChangeBearingForAircraft(aircraft.aircraftId);
+  };
+
+  return (<td onClick={onClick}>
+    {Math.round(aircraft.lastKnownBearing)}
+  </td>);
+});
+
+const Altitude = observer(({ aircraft }: SubContentProperties): JSX.Element => {
+  const onClick = (): void => {
+    if (isDragging()) return;
+    cwpStore.openLevelPopupForAircraft(aircraft.aircraftId);
+  };
+  return (<td onClick={onClick}>
+    {Number.parseFloat((aircraft.lastKnownAltitude).toFixed(0))}
+  </td>);
+});
+
+const SpeedAndWakeTurbulenceLabel = observer(({ aircraft }: SubContentProperties): JSX.Element => {
   const handleSpeedClick = (event: React.MouseEvent<HTMLElement>): void => {
     if (event.button === 1) {
-      cwpStore.openChangeSpeedForAircraft(aircraftId);
+      cwpStore.openChangeSpeedForAircraft(aircraft.aircraftId);
     }
   };
-
-  const middleClickNextWaypoint = (event: React.MouseEvent<HTMLElement>): void => {
-    if (event.button === 1) {
-      cwpStore.toggleFlightRouteForAircraft(aircraftId);
-    }
-  };
-
-  const openNSFLPopup = (): void => {
-    cwpStore.showNSFL(true);
-    cwpStore.openLevelPopupForAircraft(aircraftId);
-  };
-  const openNextACCPopup = (): void => {
-    cwpStore.showFlACC(true);
-    cwpStore.openLevelPopupForAircraft(aircraftId);
+  const onClick = (): void => {
+    if (isDragging()) return;
+    cwpStore.toggleSpeedVectorForAircraft(aircraft.aircraftId);
   };
 
   return (
-    <Container className="flight-popup-container flight-popup-pseudo-container">
-      <Row>
-        <Col className="gutter-2" onClick={(): false | void => !isDragging() && setController()}>{callSign}</Col>
-      </Row>
-      <Row>
-        <Col className="gutter-2" onClick={(): false | void => !isDragging() && cwpStore.openChangeBearingForAircraft(aircraftId)}>{Math.round(bearing)}</Col>
-        <Col className="gutter-2"/>
-        <Col className="gutter-2">{assignedBearing === -1 ? 'BEG.S' : assignedBearing}</Col>
-      </Row>
-      <Row>
-        <Col className="gutter-2" onClick={(): false | void => !isDragging() && cwpStore.openLevelPopupForAircraft(aircraftId)}>{Number.parseFloat((altitude).toFixed(0))}</Col>
-        <Col className="gutter-2" onMouseDown={middleClickNextWaypoint} onClick={(): false | void => !isDragging() && cwpStore.openChangeNextFixForAircraft(aircraftId)}>
-          {nextFix}
-        </Col>
-        <Col className="gutter-2" onClick={(): false | void => !isDragging() && cwpStore.openLevelPopupForAircraft(aircraftId)}>{assignedFlightLevel}</Col>
-      </Row>
-      <Row>
-        <Col className="gutter-2" onMouseDown={handleSpeedClick} onClick={(): false | void => !isDragging() && cwpStore.toggleSpeedVectorForAircraft(aircraftId)}>{speedAndWakeTurbulenceLabel}</Col>
-        <Col className="gutter-2" onClick={(): false | void => !isDragging() && openNSFLPopup()}>{nextSectorFL}</Col>
-        <Col className="gutter-2">{assignedSpeed === -1 ? 'S.S' : assignedSpeed}</Col>
-      </Row>
-      <Row>
-        <Col className="gutter-2" onClick={(): false | void => !isDragging() && cwpStore.openNextSectorPopupForAircraft(aircraftId)}>{nextSectorController}</Col>
-        <Col className="gutter-2">{localAssignedFlightLevel}</Col>
-        <Col className="gutter-2" onClick={(): false | void => !isDragging() && openNextACCPopup()}>{nextACCFL}</Col>
-      </Row>
-    </Container>
+    <td onMouseDown={handleSpeedClick} onClick={onClick}>
+      {aircraft.speedAndWakeTurbulenceLabel}
+    </td>
+  );
+});
+
+const NextFix = observer(({ aircraft }: SubContentProperties): JSX.Element => {
+  const middleClickNextWaypoint = (event: React.MouseEvent<HTMLElement>): void => {
+    if (event.button === 1) {
+      cwpStore.toggleFlightRouteForAircraft(aircraft.aircraftId);
+    }
+  };
+
+  const onClick = (): void => {
+    if (isDragging()) return;
+    cwpStore.openChangeNextFixForAircraft(aircraft.aircraftId);
+  };
+  const { nextFix, assignedBearing } = aircraft;
+  const showNextFix = assignedBearing === -1 || assignedBearing === undefined;
+
+  return (
+    <td onMouseDown={middleClickNextWaypoint} onClick={onClick}>
+      {showNextFix ? nextFix : '--'}
+    </td>);
+});
+
+const AssignedBearing = observer(({ aircraft }: SubContentProperties): JSX.Element => (
+  <td>
+    { aircraft.assignedBearing === -1 || aircraft.assignedBearing === undefined
+      ? 'BEG.S' : `${aircraft.assignedBearing}` }
+  </td>
+));
+
+const AssignedFlightLevel = observer(({ aircraft }: SubContentProperties): JSX.Element => {
+  const onClick = (): void => {
+    if (isDragging()) return;
+    cwpStore.openLevelPopupForAircraft(aircraft.aircraftId);
+  };
+
+  return (<td onClick={onClick}>
+    {aircraft.assignedFlightLevel}
+  </td>);
+});
+
+const NextSectorFL = observer(({ aircraft }: SubContentProperties): JSX.Element => {
+  const openNSFLPopup = (): void => {
+    if (isDragging()) return;
+    cwpStore.showNSFL(true);
+    cwpStore.openLevelPopupForAircraft(aircraft.aircraftId);
+  };
+  return (
+    <td
+        onClick={openNSFLPopup}>
+      {aircraft.nextSectorFL}
+    </td>
+  );
+});
+
+const AssignedSpeed = observer(({ aircraft }: SubContentProperties): JSX.Element => (
+  <td>{
+    aircraft.assignedSpeed === -1 || aircraft.assignedSpeed === undefined
+      ? 'S.S' : aircraft.assignedSpeed
+      }
+  </td>
+));
+
+const NextSectorController = observer(({ aircraft }: SubContentProperties): JSX.Element => {
+  const onClick = (): void => {
+    if (isDragging()) return;
+    cwpStore.openNextSectorPopupForAircraft(aircraft.aircraftId);
+  };
+  return (<td onClick={onClick}>
+    {aircraft.nextSectorController}
+  </td>);
+});
+
+const LocalAssignedFlightLevel = observer(({ aircraft }: SubContentProperties): JSX.Element => (
+  <td>
+    {aircraft.localAssignedFlightLevel}
+  </td>
+));
+
+const NextACCFlightLevel = observer(({ aircraft }: SubContentProperties): JSX.Element => {
+  const openNextACCPopup = (): void => {
+    if (isDragging()) return;
+    cwpStore.showFlACC(true);
+    cwpStore.openLevelPopupForAircraft(aircraft.aircraftId);
+  };
+
+  return (<td onClick={openNextACCPopup}>
+    {aircraft.nextACCFL}
+  </td>);
+});
+
+export default observer(function AircraftPopupPseudoContent(
+  { aircraft }: SubContentProperties,
+): JSX.Element {
+  return (
+    <table className="flight-popup-container flight-popup-pseudo-container">
+      <tbody>
+        <tr>
+          <CallSign aircraft={aircraft} />
+        </tr>
+        <tr>
+          <Bearing aircraft={aircraft}/>
+          <td></td>
+          <AssignedBearing aircraft={aircraft}/>
+        </tr>
+        <tr>
+          <Altitude aircraft={aircraft}/>
+          <NextFix aircraft={aircraft}/>
+          <AssignedFlightLevel aircraft={aircraft}/>
+        </tr>
+        <tr>
+          <SpeedAndWakeTurbulenceLabel aircraft={aircraft}/>
+          <NextSectorFL aircraft={aircraft}/>
+          <AssignedSpeed aircraft={aircraft}/>
+        </tr>
+        <tr>
+          <NextSectorController aircraft={aircraft}/>
+          <LocalAssignedFlightLevel aircraft={aircraft}/>
+          <NextACCFlightLevel aircraft={aircraft}/>
+        </tr>
+      </tbody>
+    </table>
   );
 });

--- a/src/components/AircraftPopupPseudoContent.tsx
+++ b/src/components/AircraftPopupPseudoContent.tsx
@@ -159,7 +159,7 @@ export default observer(function AircraftPopupPseudoContent(
     <table className="flight-popup-container flight-popup-pseudo-container">
       <tbody>
         <tr>
-          <CallSign aircraft={aircraft} />
+          <CallSign aircraft={aircraft} colSpan={2} />
         </tr>
         <tr>
           <Bearing aircraft={aircraft}/>

--- a/src/components/AltitudeFilterPanel.tsx
+++ b/src/components/AltitudeFilterPanel.tsx
@@ -34,22 +34,26 @@ export default observer(function AltitudeFilterPanel(/* properties */) {
             <h6>
               H:
               <input className="input-filter" style={{ width: '2.5em' }} type="text" value={highestBound}
-                onChange={(event): void => setHighBound(Number.parseInt(event.target.value, 10))} />
+                onChange={(event): void => setHighBound(
+                  Number.parseInt(event.target.value, 10) || 0)} />
               {' '}
             </h6>
             <h6>
               L:
               <input className="input-filter" style={{ width: '2.5em' }} type="text" value={lowestBound}
-                onChange={(event): void => setLowBound(Number.parseInt(event.target.value, 10))} />
+                onChange={(event): void => setLowBound(
+                  Number.parseInt(event.target.value, 10) || 0)} />
 
               {' '}
             </h6>
           </Col>
           <Col className="range-wrapper align-self-start">
             <input type="range" value={highestBound} className="range" min={lowestBound} max="1000"
-              onChange={(event): void => setHighBound(Number.parseInt(event.target.value, 10))} />
+              onChange={(event): void => setHighBound(
+                Number.parseInt(event.target.value, 10) || 0)} />
             <input type="range" value={lowestBound} className="range" min="0" max={highestBound}
-              onChange={(event): void => setLowBound(Number.parseInt(event.target.value, 10))} />
+              onChange={(event): void => setLowBound(
+                Number.parseInt(event.target.value, 10) || 0)} />
           </Col>
         </Row>
       </Card.Body>

--- a/src/components/ChangeBearingPopup.tsx
+++ b/src/components/ChangeBearingPopup.tsx
@@ -3,7 +3,7 @@ import { observer } from 'mobx-react-lite';
 import React from 'react';
 import { Button } from 'react-bootstrap';
 
-import { changeBearingOfAircraft, handlePublishPromise } from '../mqtt/publishers';
+import { changeBearingOfAircraft, handlePublishPromise, persistACCBearing } from '../mqtt/publishers';
 import { configurationStore, cwpStore } from '../state';
 import type AircraftModel from '../model/AircraftModel';
 
@@ -28,6 +28,9 @@ export default observer(function ChangeBearingPopup(properties: { aircraft: Airc
     const pilotId = configurationStore.currentCWP === 'All' ? 'All' : controlledBy;
     handlePublishPromise(
       changeBearingOfAircraft(pilotId, assignedFlightId, newBearing),
+    );
+    handlePublishPromise(
+      persistACCBearing(aircraftId, newBearing),
     );
     close();
   };

--- a/src/components/ChangeBearingPopup.tsx
+++ b/src/components/ChangeBearingPopup.tsx
@@ -15,7 +15,7 @@ export default observer(function ChangeBearingPopup(properties: { aircraft: Airc
     setAssignedBearing,
   } = properties.aircraft;
 
-  const [newBearing, setNewBearing] = React.useState(0);
+  const [newBearing, setNewBearing] = React.useState('');
 
   const shouldShow = cwpStore.aircraftsWithBearingPopup.has(aircraftId);
   if (!shouldShow) {
@@ -24,13 +24,15 @@ export default observer(function ChangeBearingPopup(properties: { aircraft: Airc
   const close = (): void => cwpStore.closeChangeBearingForAircraft(aircraftId);
 
   const submit = (): void => {
-    setAssignedBearing(newBearing);
+    const newBearingNumber = Math.max(-360, Math.min(
+      Number.parseInt(newBearing, 10) || 0, 360));
+    setAssignedBearing(newBearingNumber);
     const pilotId = configurationStore.currentCWP === 'All' ? 'All' : controlledBy;
     handlePublishPromise(
-      changeBearingOfAircraft(pilotId, assignedFlightId, newBearing),
+      changeBearingOfAircraft(pilotId, assignedFlightId, newBearingNumber),
     );
     handlePublishPromise(
-      persistACCBearing(aircraftId, newBearing),
+      persistACCBearing(aircraftId, newBearingNumber),
     );
     close();
   };
@@ -41,8 +43,7 @@ export default observer(function ChangeBearingPopup(properties: { aircraft: Airc
         New Bearing:
         <input className="input-filter-bearing" type="number" min="0" max="360"
             value={newBearing}
-            onChange={(event): void => setNewBearing(
-              Math.max(-360, Math.min(Number.parseInt(event.target.value, 10), 360)))} />
+            onChange={(event): void => setNewBearing(event.target.value)}/>
       </div>
       <div className="submit-cancel-buttons">
         <Button onClick={close} className="btn btn-light submit-cancel-button" size="sm" variant="secondary">Cancel</Button>

--- a/src/components/DraggablePopup.tsx
+++ b/src/components/DraggablePopup.tsx
@@ -26,7 +26,14 @@ export type DraggablePopupState = {
   offsetY: number,
   startX: number,
   startY: number,
+  zIndex: number,
 };
+
+let globalHighestZIndex = 0;
+function getNextZIndex(): number {
+  globalHighestZIndex += 1;
+  return globalHighestZIndex;
+}
 
 export default class DraggablePopup extends
   React.Component<DraggablePopupProperties, DraggablePopupState> {
@@ -41,7 +48,15 @@ export default class DraggablePopup extends
       offsetY: y,
       startX: 0,
       startY: 0,
+      zIndex: getNextZIndex(),
     };
+  }
+
+  incrementZIndex(): void {
+    this.setState((state) => ({
+      ...state,
+      zIndex: getNextZIndex(),
+    }));
   }
 
   onDragStart(event: DraggableEvent): void {
@@ -79,7 +94,7 @@ export default class DraggablePopup extends
     const {
       className, children, offset, color, size, cancel, ...otherProperties
     } = this.props;
-    const { offsetX, offsetY } = this.state;
+    const { offsetX, offsetY, zIndex } = this.state;
 
     // Compute the length of the line from the offset,
     // use pytagore
@@ -131,10 +146,21 @@ export default class DraggablePopup extends
 
     const displayLine = !planeIconAndCoreIntersects;
 
+    // Increase the z-index of the popup when it is clicked
+    // To make sure it is on top of other popups
+    const onClick = (): void => {
+      if (zIndex < globalHighestZIndex) {
+        this.incrementZIndex();
+      }
+    };
+
     return (
-      <Popup {...otherProperties} className="draggable-popup">
+      <Popup {...otherProperties} style={{
+        zIndex,
+      }} className="draggable-popup">
         <div
           className={`draggable-popup-core ${className ?? ''}`}
+          onMouseDown={onClick}
           style={{
             top: `${offsetY}px`,
             left: `${offsetX}px`,

--- a/src/frontendSimulationLogic.ts
+++ b/src/frontendSimulationLogic.ts
@@ -1,0 +1,120 @@
+/**
+ * This is a quick and dirty implementation of the frontend simulation logic.
+ *
+ * Sometimes we want the frontend to change a few things on its model. For example, when a flight
+ * reach the flight altitude required by the frontend.
+ *
+ * Ideally, this should be done somewhere in the backend, but this would take too much development
+ * efforts for now.
+ *
+ * Instead, each client will run a periodic check, at random intervals, and update the model
+ * accordingly, and publish the changes to the other frontends. The randomness is important to avoid
+ * having conflicting changes.
+ */
+
+import { autorun } from 'mobx';
+
+import {
+  handlePublishPromise,
+  persistACCBearing, persistACCFlightLevel, persistAssignedFlightLevel,
+  persistNextSectorFlightLevel, persistSpeedAircraft,
+} from './mqtt/publishers';
+import { aircraftStore } from './state';
+import type AircraftModel from './model/AircraftModel';
+
+function timeBeforeNextRunInMs(): number {
+  // Return a random number between 0 and 1.5s
+  return Math.round(Math.random() * 1500);
+}
+
+function runSimulationLogic(aircraft: AircraftModel): void {
+  // eslint-disable-next-line @typescript-eslint/unbound-method
+  const {
+    assignedBearing,
+    assignedFlightId,
+    assignedFlightLevel,
+    assignedSpeed,
+    lastKnownAltitude,
+    lastKnownBearing,
+    lastKnownSpeed,
+    localAssignedFlightLevel,
+    nextACCFL,
+    nextSectorFL,
+    setAssignedBearing,
+    setAssignedFlightLevel,
+    setAssignedSpeed,
+    setLocalAssignedFlightLevel,
+    setNextACCFL,
+    setNextSectorFL,
+  } = aircraft;
+
+  const stringAltitude = lastKnownAltitude.toFixed(0);
+  if (assignedFlightLevel === stringAltitude) {
+    setAssignedFlightLevel('FL.S');
+    handlePublishPromise(
+      persistAssignedFlightLevel(assignedFlightId, 'FL.S'),
+    );
+  }
+  if (localAssignedFlightLevel === stringAltitude) {
+    setLocalAssignedFlightLevel('FL.S');
+    handlePublishPromise(
+      persistAssignedFlightLevel(assignedFlightId, 'FL.S'),
+    );
+  }
+  if (nextSectorFL === stringAltitude) {
+    setNextSectorFL('NSFL');
+    handlePublishPromise(
+      persistNextSectorFlightLevel(assignedFlightId, 'NSFL'),
+    );
+  }
+  if (nextACCFL === stringAltitude) {
+    setNextACCFL('COO');
+    handlePublishPromise(
+      persistACCFlightLevel(assignedFlightId, 'COO'),
+    );
+  }
+  if (assignedBearing === Math.round(lastKnownBearing)) {
+    setAssignedBearing(-1);
+    handlePublishPromise(
+      persistACCBearing(assignedFlightId, -1),
+    );
+  }
+  if (assignedSpeed === Math.round(lastKnownSpeed)) {
+    setAssignedSpeed(-1);
+    handlePublishPromise(
+      persistSpeedAircraft(assignedFlightId, -1),
+    );
+  }
+}
+
+autorun(() => {
+  const aircrafts = aircraftStore.aircraftsWithPosition;
+  for (const aircraft of aircrafts) {
+    const {
+      assignedBearing,
+      assignedFlightLevel,
+      assignedSpeed,
+      lastKnownAltitude,
+      lastKnownBearing,
+      lastKnownSpeed,
+      localAssignedFlightLevel,
+      nextACCFL,
+      nextSectorFL,
+    } = aircraft;
+
+    // If the plane has something to be updated in its model
+    const stringAltitude = lastKnownAltitude.toFixed(0);
+    if (assignedFlightLevel === stringAltitude
+      || localAssignedFlightLevel === stringAltitude
+      || nextSectorFL === stringAltitude
+      || nextACCFL === stringAltitude
+      || assignedBearing === Math.round(lastKnownBearing)
+      || assignedSpeed === Math.round(lastKnownSpeed)) {
+      // Do the update in a random delay
+      setTimeout(
+        () => runSimulationLogic(aircraft),
+        timeBeforeNextRunInMs(),
+      );
+    }
+  }
+});

--- a/src/index.css
+++ b/src/index.css
@@ -277,12 +277,16 @@ gap: 0px;
 }
 
 .flight-popup-main .btn {
-    padding: 0 0.25rem;
+    padding: 0rem 0.2rem 0rem 1.5rem;
+    margin: 0;
     background: none;
     border: none;
     position: absolute;
     top: 0;
     right: 0;
+    line-height: 1em;
+    font-family: var(--sesar-font-mono);
+    font-size: 0.8rem;
 } 
 
 .flight-popup-main {
@@ -296,9 +300,11 @@ user-select: none;
 
 .flight-popup-container {
     border-spacing: 0;
+    width: 100%;
+    max-width: 100%;
 }
 
-.flight-popup .gutter-2 {
+.flight-popup td {
     line-height: 1.4em;
     margin: 0;
     padding: 0 0.25rem 0 0.25rem;
@@ -321,7 +327,6 @@ user-select: none;
     /* color: white; */
     padding: 0;
     margin: 0;
-    width: 11em;
     z-index: 0;
 }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,6 +7,7 @@ import '@fontsource/ibm-plex-mono';
 import './index.css';
 import './mqtt';
 import './voice/voice';
+import './frontendSimulationLogic';
 
 import React from 'react';
 import ReactDOM from 'react-dom/client';

--- a/src/model/AircraftModel.ts
+++ b/src/model/AircraftModel.ts
@@ -265,11 +265,11 @@ export default class AircraftModel {
   }
 
   setAssignedBearing(assignedBearing: number): void {
-    this.assignedBearing = assignedBearing;
+    this.assignedBearing = assignedBearing === -1 ? undefined : assignedBearing;
   }
 
   setAssignedSpeed(assignedSpeed: number): void {
-    this.assignedSpeed = assignedSpeed;
+    this.assignedSpeed = assignedSpeed === -1 ? undefined : assignedSpeed;
   }
 
   setLocalAssignedFlightLevel(localAssignedFlightLevel: string): void {

--- a/src/model/AircraftStore.ts
+++ b/src/model/AircraftStore.ts
@@ -204,4 +204,8 @@ export default class AircraftStore {
   handleFrontendSpeed(flightId: string, speed: number): void {
     this.aircrafts.get(flightId)?.setAssignedSpeed(speed);
   }
+
+  handleFrontendLocalAssignedFlightLevel(flightId: string, flightLevel: string): void {
+    this.aircrafts.get(flightId)?.setLocalAssignedFlightLevel(flightLevel);
+  }
 }

--- a/src/model/AircraftStore.ts
+++ b/src/model/AircraftStore.ts
@@ -192,4 +192,16 @@ export default class AircraftStore {
   handleFrontendNextSectorFlightLevel(flightId: string, flightLevel: string): void {
     this.aircrafts.get(flightId)?.setNextSectorFL(flightLevel);
   }
+
+  handleFrontendACCBearing(flightId: string, bearing: number): void {
+    this.aircrafts.get(flightId)?.setAssignedBearing(bearing);
+  }
+
+  handleFrontendAssignedFlightLevel(flightId: string, flightLevel: string): void {
+    this.aircrafts.get(flightId)?.setAssignedFlightLevel(flightLevel);
+  }
+
+  handleFrontendSpeed(flightId: string, speed: number): void {
+    this.aircrafts.get(flightId)?.setAssignedSpeed(speed);
+  }
 }

--- a/src/mqtt/publishers.ts
+++ b/src/mqtt/publishers.ts
@@ -104,7 +104,7 @@ export async function persistACCFlightLevel(
   );
 }
 
-export async function persistNextSectorFlightSpeed(
+export async function persistNextSectorFlightLevel(
   flightUniqueId: string,
   flightLevel: string,
 ): Promise<void> {
@@ -148,6 +148,16 @@ export async function persistSpeedAircraft(
 ): Promise<void> {
   await publish(`frontend/${clientId}/flight/${flightUniqueId}/speed`,
     speed.toFixed(0),
+    { retain: true },
+  );
+}
+
+export async function persistLocalAssignedFlightLevel(
+  flightUniqueId: string,
+  flightLevel: string,
+): Promise<void> {
+  await publish(`frontend/${clientId}/flight/${flightUniqueId}/localAssignedFL`,
+    flightLevel,
     { retain: true },
   );
 }

--- a/src/mqtt/publishers.ts
+++ b/src/mqtt/publishers.ts
@@ -114,10 +114,40 @@ export async function persistNextSectorFlightSpeed(
   );
 }
 
+export async function persistACCBearing(
+  flightUniqueId: string,
+  bearing: number,
+): Promise<void> {
+  await publish(`frontend/${clientId}/flight/${flightUniqueId}/ACCBearing`,
+    bearing.toFixed(0),
+    { retain: true },
+  );
+}
+
+export async function persistAssignedFlightLevel(
+  flightUniqueId: string,
+  flightLevel: string,
+): Promise<void> {
+  await publish(`frontend/${clientId}/flight/${flightUniqueId}/assignedFL`,
+    flightLevel,
+    { retain: true },
+  );
+}
+
 export async function tentativeFlight(
   fromControllableSector: string, toControllableSector: string, flightUniqueId: string,
 ): Promise<void> {
   await publish(`simulator/${clientId}/tentativeFlight/`,
     serializeForSimulator(fromControllableSector, toControllableSector, flightUniqueId),
+  );
+}
+
+export async function persistSpeedAircraft(
+  flightUniqueId: string,
+  speed: number,
+): Promise<void> {
+  await publish(`frontend/${clientId}/flight/${flightUniqueId}/speed`,
+    speed.toFixed(0),
+    { retain: true },
   );
 }

--- a/src/mqtt/router.ts
+++ b/src/mqtt/router.ts
@@ -1,7 +1,6 @@
 import rlite from 'rlite-router';
 
 import {
-  acceptedFlightMessage,
   airspaceAvailability,
   airspaces,
   airTrafficControllerMessage,
@@ -18,7 +17,6 @@ import {
   newAircraftMessage,
   newAircraftTypeMessage,
   newAirspaceConfiguration,
-  newAirspaceVolumeFlightList,
   newAvailabilityIntervalsMessage,
   newFlight,
   newFlightMilestonePositions,
@@ -27,7 +25,6 @@ import {
   notFound,
   roleConfiguration,
   targetReport,
-  tentativeFlightMessage,
 } from './subscribers';
 
 const router = rlite<Buffer>(notFound, {
@@ -57,9 +54,9 @@ const router = rlite<Buffer>(notFound, {
   'ATM/:clientId/CurrentAirspaceConfiguration': currentAirspaceConfiguration,
   'ATM/:clientId/AirTrafficControllerAssignmentMessage/:objectId/:time': airTrafficControllerMessage,
   'ATM/:clientId/TesselatedAirspaceVolume/:airspaceVolumeId': ignored,
-  'ATM/:clientId/NewAirspaceVolumeFlightListMessage/:airspaceVolumeId': newAirspaceVolumeFlightList,
-  'ATM/:clientId/AddAcceptedFlightMessage/:toControllableAirspaceVolume/:flightId': acceptedFlightMessage,
-  'ATM/:clientId/AddTentativeFlightMessage/:toControllableAirspaceVolume/:flightId': tentativeFlightMessage,
+  'ATM/:clientId/NewAirspaceVolumeFlightListMessage/:airspaceVolumeId': ignored,
+  'ATM/:clientId/AddAcceptedFlightMessage/:toControllableAirspaceVolume/:flightId': ignored,
+  'ATM/:clientId/AddTentativeFlightMessage/:toControllableAirspaceVolume/:flightId': ignored,
   'ATM/:clientId/status/time': newSimulatorTime,
   'ATM/:clientId/status/:status': ignored,
   'frontend/:clientId/flight/:flightId/controller': frontendFlightController,

--- a/src/mqtt/router.ts
+++ b/src/mqtt/router.ts
@@ -11,6 +11,7 @@ import {
   frontendACCFlightLevel,
   frontendAssignedFlightLevel,
   frontendFlightController,
+  frontendLocalAssignedFlightLevel,
   frontendNextSectorFlightLevel,
   frontendSpeed,
   ignored,
@@ -67,6 +68,7 @@ const router = rlite<Buffer>(notFound, {
   'frontend/:clientId/flight/:flightId/ACCBearing': frontendACCBearing,
   'frontend/:clientId/flight/:flightId/assignedFL': frontendAssignedFlightLevel,
   'frontend/:clientId/flight/:flightId/speed': frontendSpeed,
+  'frontend/:clientId/flight/:flightId/localAssignedFL': frontendLocalAssignedFlightLevel,
 });
 
 export default router;

--- a/src/mqtt/router.ts
+++ b/src/mqtt/router.ts
@@ -7,9 +7,12 @@ import {
   airTrafficControllerMessage,
   currentAirspaceConfiguration,
   flightRoutes,
+  frontendACCBearing,
   frontendACCFlightLevel,
+  frontendAssignedFlightLevel,
   frontendFlightController,
   frontendNextSectorFlightLevel,
+  frontendSpeed,
   ignored,
   newAircraftMessage,
   newAircraftTypeMessage,
@@ -61,6 +64,9 @@ const router = rlite<Buffer>(notFound, {
   'frontend/:clientId/flight/:flightId/controller': frontendFlightController,
   'frontend/:clientId/flight/:flightId/ACCFL': frontendACCFlightLevel,
   'frontend/:clientId/flight/:flightId/NSFL': frontendNextSectorFlightLevel,
+  'frontend/:clientId/flight/:flightId/ACCBearing': frontendACCBearing,
+  'frontend/:clientId/flight/:flightId/assignedFL': frontendAssignedFlightLevel,
+  'frontend/:clientId/flight/:flightId/speed': frontendSpeed,
 });
 
 export default router;

--- a/src/mqtt/subscribers.ts
+++ b/src/mqtt/subscribers.ts
@@ -148,7 +148,7 @@ export function frontendACCBearing(
   { flightId }: { [key: string]: string },
   message: Buffer,
 ): void {
-  const bearing = Number.parseInt(message.toString(), 10) ?? 0;
+  const bearing = Number.parseInt(message.toString(), 10) || 0;
   aircraftStore.handleFrontendACCBearing(flightId, bearing);
 }
 
@@ -164,6 +164,14 @@ export function frontendSpeed(
   { flightId }: { [key: string]: string },
   message: Buffer,
 ): void {
-  const speed = Number.parseInt(message.toString(), 10) ?? 0;
+  const speed = Number.parseInt(message.toString(), 10) || 0;
   aircraftStore.handleFrontendSpeed(flightId, speed);
+}
+
+export function frontendLocalAssignedFlightLevel(
+  { flightId }: { [key: string]: string },
+  message: Buffer,
+): void {
+  const level = message.toString();
+  aircraftStore.handleFrontendLocalAssignedFlightLevel(flightId, level);
 }

--- a/src/mqtt/subscribers.ts
+++ b/src/mqtt/subscribers.ts
@@ -143,3 +143,27 @@ export function frontendNextSectorFlightLevel(
   const level = message.toString();
   aircraftStore.handleFrontendNextSectorFlightLevel(flightId, level);
 }
+
+export function frontendACCBearing(
+  { flightId }: { [key: string]: string },
+  message: Buffer,
+): void {
+  const bearing = Number.parseInt(message.toString(), 10) ?? 0;
+  aircraftStore.handleFrontendACCBearing(flightId, bearing);
+}
+
+export function frontendAssignedFlightLevel(
+  { flightId }: { [key: string]: string },
+  message: Buffer,
+): void {
+  const level = message.toString();
+  aircraftStore.handleFrontendAssignedFlightLevel(flightId, level);
+}
+
+export function frontendSpeed(
+  { flightId }: { [key: string]: string },
+  message: Buffer,
+): void {
+  const speed = Number.parseInt(message.toString(), 10) ?? 0;
+  aircraftStore.handleFrontendSpeed(flightId, speed);
+}

--- a/src/mqtt/subscribers.ts
+++ b/src/mqtt/subscribers.ts
@@ -1,6 +1,4 @@
 import {
-  AddAcceptedFlightMessage,
-  AddTentativeFlightMessage,
   AirspaceAvailabilityMessage,
   AirTrafficControllerAssignmentMessage,
   AvailabilityIntervalsMessage,
@@ -11,7 +9,6 @@ import {
   NewAircraftTypeMessage,
   NewAirspaceConfigurationMessage,
   NewAirspaceMessage,
-  NewAirspaceVolumeFlightListMessage,
   NewFlightMessage,
   NewPointMessage,
   RoleConfigurationMessage,
@@ -74,12 +71,6 @@ export function flightRoutes(parameters: unknown, message: Buffer): void {
   const protoMessage = FlightRouteMessage.fromBinary(message);
   aircraftStore.handleNewFlightRoute(protoMessage);
 }
-export function newAirspaceVolumeFlightList(parameters: unknown, message: Buffer): void {
-  const protoMessage = NewAirspaceVolumeFlightListMessage
-    .fromBinary(message);
-  // eslint-disable-next-line no-console
-  console.warn('TODO', protoMessage);
-}
 export function airspaceAvailability(parameters: unknown, message: Buffer): void {
   const protoMessage = AirspaceAvailabilityMessage.fromBinary(message);
   configurationStore.handleAvailabilityMessage(protoMessage);
@@ -92,24 +83,11 @@ export function newSimulatorTime(parameters: unknown, message: Buffer): void {
 
 export function newFlightMilestonePositions(parameters: unknown, message: Buffer): void {
   const protoMessage = FlightMilestonePositionMessage.fromBinary(message);
-  // fixStore.handleNewMilestoneMessage(protoMessage);
   aircraftStore.handleFlightNewMilestonePositions(protoMessage);
 }
 export function newAvailabilityIntervalsMessage(parameters: unknown, message: Buffer): void {
   const protoMessage = AvailabilityIntervalsMessage.fromBinary(message);
   configurationStore.handleAvailabilityIntervalsMessage(protoMessage);
-}
-export function acceptedFlightMessage(parameters: unknown, message: Buffer): void {
-  const protoMessage = AddAcceptedFlightMessage.fromBinary(message);
-  // eslint-disable-next-line no-console
-  console.log(protoMessage);
-  // aircraftStore.handleAcceptedFlightMessage(protoMessage);
-}
-export function tentativeFlightMessage(parameters: unknown, message: Buffer): void {
-  const protoMessage = AddTentativeFlightMessage.fromBinary(message);
-  // eslint-disable-next-line no-console
-  console.log(protoMessage);
-  // aircraftStore.handleTentativeFlightMessage(protoMessage);
 }
 export function roleConfiguration(parameters: unknown, message: Buffer): void {
   const protoMessage = RoleConfigurationMessage.fromBinary(message);

--- a/src/voice/ThreeDViewCommand.ts
+++ b/src/voice/ThreeDViewCommand.ts
@@ -9,7 +9,7 @@ export default function ThreeDViewCommand(_arguments: string[]): void {
     throw new Error('Missing orientation');
   }
   const hasAngle = angle !== undefined;
-  const angleNumber = (Number.parseInt(angle, 10) ?? 0) % 360;
+  const angleNumber = (Number.parseInt(angle, 10) || 0) % 360;
 
   const map = getMap();
   const bearing = map.getBearing();


### PR DESCRIPTION
List of changes:

 - Completed persistence and sharing across clients
 - Big Optimisation suggestion: Do not automatically open flight labels of flights more than 100km away from the sectors. This could be increased. Many flight labels were computed while the planes were extremely far away.
 - Complete refactoring of AircraftPopupContent and AircraftPopupPseudoContent
   - Split in many small components to improve mobx performances
   - Separate the logic to update the model when a flight reaches an altitude or a speed or a bearing into a separate file.
   - Use a HTML table instead of a bootstrap grid, which is a bit faster and also closer to what we want.
 - Fix the parseInt logic with NaN : it was `||` and not `??`
 - Improve the number inputs in the popups, using strings in states instead of numbers. This fixes a few strange behaviours with empty strings or numbers outside the range.
 - Implement logic to always have the current popup above the others. This is done by using a z-index.
 - Little code cleaning.