### PR TITLE
Remove aircraft type display from Aircraft components

### DIFF
--- a/src/components/AircraftContentSmall.tsx
+++ b/src/components/AircraftContentSmall.tsx
@@ -65,7 +65,6 @@ export default observer(function AircraftContentSmall(properties: {
 					{formatSpeed(lastKnownSpeed)}
 				</span>
 				<span className="ml-1">&nbsp;&nbsp;</span>
-				<span>{aircraft.aircraftType}</span>
 			</div>
 			{/* Line 1 */}
 			<div>

--- a/src/components/AircraftPopupContent.tsx
+++ b/src/components/AircraftPopupContent.tsx
@@ -25,8 +25,7 @@ export default observer(function AircraftPopupContent(properties: {
 	const { isDragging } = useDragging();
 	const { aircraft, flightColor } = properties;
 	// const currentSector = roleConfigurationStore.currentControlledSector;
-	const { lastKnownSpeed, lastKnownVerticalSpeed, aircraftType, nextSector } =
-		aircraft;
+	const { lastKnownSpeed, lastKnownVerticalSpeed, nextSector } = aircraft;
 
 	const openSpeedPopup = (): void => {
 		if (isDragging) {
@@ -54,8 +53,6 @@ export default observer(function AircraftPopupContent(properties: {
 				</span>
 				<span className="ml-0.5"></span>
 				<span>{formatVerticalSpeed(lastKnownVerticalSpeed)}</span>
-				<span className="ml-0.5"></span>
-				<span>{aircraftType}</span>
 			</div>
 			{/* Line 1 */}
 			<div>


### PR DESCRIPTION
Eliminate the display of aircraft type in both AircraftContentSmall and AircraftPopupContent components to streamline the user interface.