### PR TITLE
Reset heading prediction and maintain display until new waypoint

### DIFF
--- a/src/components/AircraftContentSmall.tsx
+++ b/src/components/AircraftContentSmall.tsx
@@ -31,7 +31,12 @@ export default observer(function AircraftContentSmall(properties: {
 	};
 
 	const displayBearing = (): JSX.Element | null => {
-		return <AssignedBearing aircraft={aircraft} />;
+		return (
+			<AssignedBearing
+				aircraft={aircraft}
+				showPlaceholderWhenNotRerouted={false}
+			/>
+		);
 	};
 
 	return (

--- a/src/components/AircraftContentSmall.tsx
+++ b/src/components/AircraftContentSmall.tsx
@@ -9,6 +9,7 @@ import {
 	AssignedBearing,
 	CallSign,
 	NextACCFlightLevel,
+	NextNav,
 	NextSectorFL,
 	VerticalSpeedIcon,
 	WarningIcon,
@@ -32,10 +33,13 @@ export default observer(function AircraftContentSmall(properties: {
 
 	const displayBearing = (): JSX.Element | null => {
 		return (
-			<AssignedBearing
-				aircraft={aircraft}
-				showPlaceholderWhenNotRerouted={false}
-			/>
+			<>
+				<NextNav aircraft={aircraft} showInUnsetMode={false} />
+				<AssignedBearing
+					aircraft={aircraft}
+					showPlaceholderWhenNotRerouted={false}
+				/>
+			</>
 		);
 	};
 

--- a/src/components/AircraftContentSmall.tsx
+++ b/src/components/AircraftContentSmall.tsx
@@ -21,7 +21,7 @@ export default observer(function AircraftContentSmall(properties: {
 }) {
 	const { isDragging } = useDragging();
 	const { aircraft, flightColor } = properties;
-	const { lastKnownSpeed, assignedBearing, lastKnownBearing } = aircraft;
+	const { lastKnownSpeed } = aircraft;
 
 	const openSpeedPopup = (): void => {
 		if (isDragging) {
@@ -31,18 +31,7 @@ export default observer(function AircraftContentSmall(properties: {
 	};
 
 	const displayBearing = (): JSX.Element | null => {
-		const hasBearingAssigned =
-			assignedBearing !== undefined && assignedBearing !== -1;
-
-		if (!hasBearingAssigned) {
-			return null;
-		}
-		// Check if bearing is still changing (with a small tolerance of 2 degrees)
-		const bearingDifference = Math.abs(assignedBearing - lastKnownBearing);
-		const normalizedDiff = Math.min(bearingDifference, 360 - bearingDifference);
-		const isBearingChanging = normalizedDiff > 2;
-
-		return isBearingChanging ? <AssignedBearing aircraft={aircraft} /> : null;
+		return <AssignedBearing aircraft={aircraft} />;
 	};
 
 	return (

--- a/src/components/AircraftLabelParts.tsx
+++ b/src/components/AircraftLabelParts.tsx
@@ -495,54 +495,99 @@ export const BearingChangeIcon = observer(
 	},
 );
 
-export const NextNav = observer(({ aircraft }: SubContentProperties) => {
-	const posthog = usePostHog();
-	const { isDragging } = useDragging();
+const ReroutedViaWaypointIcon = () => (
+	<svg
+		viewBox="0 0 24 24"
+		xmlns="http://www.w3.org/2000/svg"
+		className="inline-block ml-0.5 size-2.5 -mt-px fill-none mr-0.5"
+		strokeWidth="2"
+	>
+		<polyline points="16 3 21 3 21 8" stroke="currentColor"></polyline>
+		<line x1="4" y1="20" x2="21" y2="3" stroke="currentColor"></line>
+		<polyline points="21 16 21 21 16 21" stroke="currentColor"></polyline>
+		<line x1="15" y1="15" x2="21" y2="21" stroke="currentColor"></line>
+		<line x1="4" y1="4" x2="9" y2="9" stroke="currentColor"></line>
+	</svg>
+);
 
-	const middleClickNextWaypoint = (
-		event: React.MouseEvent<HTMLElement>,
-	): void => {
-		if (event.button !== 1) {
-			return;
+export const NextNav = observer(
+	({
+		aircraft,
+		showInUnsetMode = true,
+		showPlaceholderWhenRerouted = true,
+	}: SubContentProperties & {
+		showInUnsetMode?: boolean;
+		showPlaceholderWhenRerouted?: boolean;
+	}) => {
+		const posthog = usePostHog();
+		const { isDragging } = useDragging();
+
+		const middleClickNextWaypoint = (
+			event: React.MouseEvent<HTMLElement>,
+		): void => {
+			if (event.button !== 1) {
+				return;
+			}
+
+			cwpStore.toggleFlightRouteForAircraft(aircraft.aircraftId);
+			posthog?.capture("next_nav_clicked", {
+				aircraft_id: aircraft.aircraftId,
+				callsign: aircraft.callSign,
+				next_nav: aircraft.nextNav,
+				flight_route_visible: cwpStore.aircraftsWithFlightRoutes.has(
+					aircraft.aircraftId,
+				),
+			});
+		};
+
+		const openNextFixPopup = (): void => {
+			if (isDragging) {
+				return;
+			}
+
+			cwpStore.openChangeNextFixForAircraft(aircraft.aircraftId);
+			posthog?.capture("next_fix_popup_opened", {
+				aircraft_id: aircraft.aircraftId,
+				callsign: aircraft.callSign,
+				next_nav: aircraft.nextNav,
+			});
+		};
+
+		const {
+			nextNav,
+			predictiveTrajectoryMode,
+			predictiveTrajectoryWaypointId,
+		} = aircraft;
+
+		let content: React.ReactNode = null;
+		if (predictiveTrajectoryMode === "unset") {
+			content = showInUnsetMode ? nextNav : null;
+		} else if (predictiveTrajectoryMode === "rerouted-via-waypoint") {
+			content = predictiveTrajectoryWaypointId ? (
+				<>
+					<ReroutedViaWaypointIcon />
+					{predictiveTrajectoryWaypointId}
+				</>
+			) : null;
+		} else if (showPlaceholderWhenRerouted) {
+			content = "--";
 		}
 
-		cwpStore.toggleFlightRouteForAircraft(aircraft.aircraftId);
-		posthog?.capture("next_nav_clicked", {
-			aircraft_id: aircraft.aircraftId,
-			callsign: aircraft.callSign,
-			next_nav: aircraft.nextNav,
-			flight_route_visible: cwpStore.aircraftsWithFlightRoutes.has(
-				aircraft.aircraftId,
-			),
-		});
-	};
-
-	const openNextFixPopup = (): void => {
-		if (isDragging) {
-			return;
+		if (!content) {
+			return null;
 		}
 
-		cwpStore.openChangeNextFixForAircraft(aircraft.aircraftId);
-		posthog?.capture("next_fix_popup_opened", {
-			aircraft_id: aircraft.aircraftId,
-			callsign: aircraft.callSign,
-			next_nav: aircraft.nextNav,
-		});
-	};
-
-	const { nextNav } = aircraft;
-	const showNextNav = aircraft.predictiveTrajectoryMode !== "rerouted";
-
-	return (
-		<span
-			onClick={openNextFixPopup}
-			onMouseDown={middleClickNextWaypoint}
-			className="hover:outline-2 hover:outline-white"
-		>
-			{showNextNav ? nextNav : "--"}
-		</span>
-	);
-});
+		return (
+			<span
+				onClick={openNextFixPopup}
+				onMouseDown={middleClickNextWaypoint}
+				className="hover:outline-2 hover:outline-white"
+			>
+				{content}
+			</span>
+		);
+	},
+);
 
 export const TransferAltitude = ({
 	altitude,

--- a/src/components/AircraftLabelParts.tsx
+++ b/src/components/AircraftLabelParts.tsx
@@ -403,7 +403,12 @@ export const WarningIcon = observer(
 );
 
 export const AssignedBearing = observer(
-	({ aircraft }: SubContentProperties) => {
+	({
+		aircraft,
+		showPlaceholderWhenNotRerouted = true,
+	}: SubContentProperties & {
+		showPlaceholderWhenNotRerouted?: boolean;
+	}) => {
 		const { assignedBearing, lastKnownBearing } = aircraft;
 		const changeBearing = (): void => {
 			cwpStore.openChangeBearingForAircraft(aircraft.aircraftId);
@@ -412,6 +417,10 @@ export const AssignedBearing = observer(
 		const isPredictiveTrajectoryRerouted =
 			aircraft.predictiveTrajectoryMode === "rerouted";
 		if (!isPredictiveTrajectoryRerouted) {
+			if (!showPlaceholderWhenNotRerouted) {
+				return null;
+			}
+
 			return (
 				<span
 					onClick={changeBearing}

--- a/src/components/AircraftLabelParts.tsx
+++ b/src/components/AircraftLabelParts.tsx
@@ -404,11 +404,14 @@ export const WarningIcon = observer(
 
 export const AssignedBearing = observer(
 	({ aircraft }: SubContentProperties) => {
-		const { assignedBearing } = aircraft;
+		const { assignedBearing, lastKnownBearing } = aircraft;
 		const changeBearing = (): void => {
 			cwpStore.openChangeBearingForAircraft(aircraft.aircraftId);
 		};
-		if (assignedBearing === -1 || assignedBearing === undefined) {
+
+		const isPredictiveTrajectoryRerouted =
+			aircraft.predictiveTrajectoryMode === "rerouted";
+		if (!isPredictiveTrajectoryRerouted) {
 			return (
 				<span
 					onClick={changeBearing}
@@ -419,7 +422,19 @@ export const AssignedBearing = observer(
 			);
 		}
 
-		let displayedBearing = Math.round(assignedBearing) % 360;
+		const hasAssignedBearing =
+			assignedBearing !== undefined && assignedBearing !== -1;
+		const bearingToDisplay = hasAssignedBearing
+			? assignedBearing
+			: isPredictiveTrajectoryRerouted
+				? lastKnownBearing
+				: undefined;
+
+		if (bearingToDisplay === undefined) {
+			return null;
+		}
+
+		let displayedBearing = Math.round(bearingToDisplay) % 360;
 		if (displayedBearing < 1) {
 			displayedBearing = 360;
 		}
@@ -442,22 +457,9 @@ export const AssignedBearing = observer(
  */
 export const BearingChangeIcon = observer(
 	({ aircraft }: SubContentProperties) => {
-		const { assignedBearing, lastKnownBearing } = aircraft;
-
-		// Only show icon when bearing is assigned and aircraft hasn't reached target heading yet
-		const hasBearingAssigned =
-			assignedBearing !== undefined && assignedBearing !== -1;
-
-		if (!hasBearingAssigned) {
-			return null;
-		}
-
-		// Check if bearing is still changing (with a small tolerance of 2 degrees)
-		const bearingDifference = Math.abs(assignedBearing - lastKnownBearing);
-		const normalizedDiff = Math.min(bearingDifference, 360 - bearingDifference);
-		const isBearingChanging = normalizedDiff > 2;
-
-		if (!isBearingChanging) {
+		const isPredictiveTrajectoryRerouted =
+			aircraft.predictiveTrajectoryMode === "rerouted";
+		if (!isPredictiveTrajectoryRerouted) {
 			return null;
 		}
 
@@ -519,8 +521,8 @@ export const NextNav = observer(({ aircraft }: SubContentProperties) => {
 		});
 	};
 
-	const { nextNav, assignedBearing } = aircraft;
-	const showNextNav = assignedBearing === -1 || assignedBearing === undefined;
+	const { nextNav } = aircraft;
+	const showNextNav = aircraft.predictiveTrajectoryMode !== "rerouted";
 
 	return (
 		<span

--- a/src/components/ChangeNextFixPopup.tsx
+++ b/src/components/ChangeNextFixPopup.tsx
@@ -345,24 +345,14 @@ export default observer(function ChangeNextFixPopup(properties: {
 			applyFix(fix, "rt");
 			return;
 		}
-		if (fix === nextFix) {
-			// Clicking the current next fix normally closes the popup.
-			// If predictive state is active (e.g. from heading changes),
-			// treat this as an explicit reset action and sync it via MQTT.
-			if (properties.aircraft.predictiveTrajectoryMode !== "unset") {
-				properties.aircraft.clearPredictiveTrajectoryState();
-				handlePublishPromise(clearPredictiveTrajectoryState(assignedFlightId));
-				posthog?.capture("predictive_trajectory_state_changed", {
-					flight_id: assignedFlightId,
-					aircraft_id: aircraftId,
-					mode: "unset",
-					source: "change_next_fix_popup_current_fix_click",
-					waypoint_id: fix,
-				});
-			}
+		if (
+			fix === nextFix &&
+			properties.aircraft.predictiveTrajectoryMode === "unset"
+		) {
+			// No route or predictive change to apply.
 			close();
 		} else {
-			// Otherwise, apply immediately
+			// Apply immediately, including same-fix clicks when predictive mode is active.
 			applyFix(fix, "rt");
 		}
 	};

--- a/src/components/ChangeNextFixPopup.tsx
+++ b/src/components/ChangeNextFixPopup.tsx
@@ -346,7 +346,20 @@ export default observer(function ChangeNextFixPopup(properties: {
 			return;
 		}
 		if (fix === nextFix) {
-			// If clicking on the current fix (no change), just close the popup
+			// Clicking the current next fix normally closes the popup.
+			// If predictive state is active (e.g. from heading changes),
+			// treat this as an explicit reset action and sync it via MQTT.
+			if (properties.aircraft.predictiveTrajectoryMode !== "unset") {
+				properties.aircraft.clearPredictiveTrajectoryState();
+				handlePublishPromise(clearPredictiveTrajectoryState(assignedFlightId));
+				posthog?.capture("predictive_trajectory_state_changed", {
+					flight_id: assignedFlightId,
+					aircraft_id: aircraftId,
+					mode: "unset",
+					source: "change_next_fix_popup_current_fix_click",
+					waypoint_id: fix,
+				});
+			}
 			close();
 		} else {
 			// Otherwise, apply immediately

--- a/src/model/AircraftModel.ts
+++ b/src/model/AircraftModel.ts
@@ -676,6 +676,8 @@ export default class AircraftModel {
 		latitude: number,
 		longitude: number,
 	): void {
+		// Entering direct-to mode: clear heading assignment to avoid stale ACC bearing.
+		this.assignedBearing = undefined;
 		this.predictiveTrajectoryMode = "rerouted-via-waypoint";
 		this.predictiveTrajectoryWaypointId = waypointId;
 		this.predictiveTrajectoryWaypointLatitude = latitude;
@@ -683,6 +685,8 @@ export default class AircraftModel {
 	}
 
 	clearPredictiveTrajectoryState(): void {
+		// Returning to nominal route mode: heading assignment is no longer active.
+		this.assignedBearing = undefined;
 		this.predictiveTrajectoryMode = "unset";
 		this.predictiveTrajectoryWaypointId = undefined;
 		this.predictiveTrajectoryWaypointLatitude = undefined;


### PR DESCRIPTION
Clear heading predictive state when selecting the next waypoint in the flight plan. Ensure the assigned heading remains visible until a new waypoint is set, addressing the issues of disappearing heading information.

Fixes #481, Fixes #457