### PR TITLE
feat: warning labels are synced per label

### DIFF
--- a/src/components/AircraftLabelParts.tsx
+++ b/src/components/AircraftLabelParts.tsx
@@ -300,7 +300,6 @@ function getWarningIconPath(warningLevel: string): React.ReactNode {
 	}
 }
 
-
 /**
  * Warning icon component that works with just an aircraftId.
  * Can be used anywhere without needing the full AircraftModel.

--- a/src/components/AircraftLabelParts.tsx
+++ b/src/components/AircraftLabelParts.tsx
@@ -10,6 +10,10 @@ import { useDragging } from "../contexts/DraggingContext";
 import type AircraftModel from "../model/AircraftModel";
 import { FLIGHT_LABEL_COLORS } from "../model/CwpStore";
 import { isMovingAwayFromWaypoint } from "../model/predictiveTrajectory";
+import {
+	handlePublishPromise,
+	persistWarningLevel,
+} from "../mqtt-client/publishers";
 import { configurationStore, cwpStore, roleConfigurationStore } from "../state";
 import { convertMetersToFlightLevel } from "../utils";
 
@@ -296,23 +300,6 @@ function getWarningIconPath(warningLevel: string): React.ReactNode {
 	}
 }
 
-/**
- * Compute the next warning level in the cycle: none -> blue -> yellow -> orange -> none
- */
-function getNextWarningLevel(currentLevel: string): string {
-	switch (currentLevel) {
-		case "none":
-			return "blue";
-		case "blue":
-			return "yellow";
-		case "yellow":
-			return "orange";
-		case "orange":
-			return "none";
-		default:
-			return "blue";
-	}
-}
 
 /**
  * Warning icon component that works with just an aircraftId.
@@ -340,8 +327,14 @@ export const WarningIconById = observer(
 		const handleClick = (event: React.MouseEvent): void => {
 			event.stopPropagation();
 			const previousLevel = warningLevel;
-			const newLevel = getNextWarningLevel(previousLevel);
-			cwpStore.cycleWarningLevel(aircraftId);
+			const newLevel = cwpStore.cycleWarningLevel(aircraftId);
+			handlePublishPromise(
+				persistWarningLevel(
+					aircraftId,
+					newLevel,
+					configurationStore.currentCWP,
+				),
+			);
 			posthog.capture("warning_level_cycled", {
 				aircraft_id: aircraftId,
 				callsign: undefined,
@@ -379,8 +372,14 @@ export const WarningIcon = observer(
 		const handleClick = (event: React.MouseEvent): void => {
 			event.stopPropagation();
 			const previousLevel = warningLevel;
-			const newLevel = getNextWarningLevel(previousLevel);
-			cwpStore.cycleWarningLevel(aircraft.aircraftId);
+			const newLevel = cwpStore.cycleWarningLevel(aircraft.aircraftId);
+			handlePublishPromise(
+				persistWarningLevel(
+					aircraft.aircraftId,
+					newLevel,
+					configurationStore.currentCWP,
+				),
+			);
 			posthog.capture("warning_level_cycled", {
 				aircraft_id: aircraft.aircraftId,
 				callsign: aircraft.callSign,

--- a/src/components/ImageConfiguration.tsx
+++ b/src/components/ImageConfiguration.tsx
@@ -4,6 +4,10 @@ import { usePostHog } from "posthog-js/react";
 import React from "react";
 
 import {
+	handlePublishPromise,
+	persistWarningLevel,
+} from "../mqtt-client/publishers";
+import {
 	configurationStore,
 	cwpStore,
 	distanceLineStore,
@@ -131,6 +135,12 @@ const AirwaysButton = observer(function AirwaysButton() {
 const ResetButton = observer(function ResetButton() {
 	const posthog = usePostHog();
 	const resetAll = (): void => {
+		// Clear retained MQTT messages for all active warning levels before resetting
+		const role = configurationStore.currentCWP;
+		for (const aircraftId of cwpStore.aircraftWarningLevels.keys()) {
+			handlePublishPromise(persistWarningLevel(aircraftId, "none", role));
+		}
+
 		// Reset per-aircraft UI state (selections, warnings, popups)
 		cwpStore.resetUIState();
 

--- a/src/components/SpeedVectors.tsx
+++ b/src/components/SpeedVectors.tsx
@@ -4,6 +4,10 @@ import { useCallback, useEffect } from "react";
 import { Layer, Source, useMap } from "react-map-gl/maplibre";
 import type AircraftModel from "../model/AircraftModel";
 import {
+	handlePublishPromise,
+	persistWarningLevel,
+} from "../mqtt-client/publishers";
+import {
 	aircraftStore,
 	configurationStore,
 	cwpStore,
@@ -190,7 +194,14 @@ export default observer(function SpeedVectors({ beforeId }: SpeedVectorsProps) {
 				const aircraftId = features[0].properties?.aircraftId as unknown;
 				if (typeof aircraftId === "string") {
 					event.preventDefault();
-					cwpStore.cycleWarningLevel(aircraftId);
+					const newLevel = cwpStore.cycleWarningLevel(aircraftId);
+					handlePublishPromise(
+						persistWarningLevel(
+							aircraftId,
+							newLevel,
+							configurationStore.currentCWP,
+						),
+					);
 				}
 			}
 		};

--- a/src/model/CwpStore.ts
+++ b/src/model/CwpStore.ts
@@ -194,6 +194,9 @@ export default class CWPStore {
 
 	highligtedAircraftIdTimeoutId = 0;
 
+	/** Warning levels received before role selection, keyed by role name then flightId */
+	warningLevelBuffer: Map<string, Map<string, WarningLevel>> = new Map();
+
 	disabledCWPIn3DView: ObservableSet<string> = observable.set(undefined, {
 		deep: false,
 	});
@@ -243,6 +246,7 @@ export default class CWPStore {
 				highligtedAircraftIdTimeoutId: false,
 				switchBackToAutomaticNextSectorsConfigurationTimeoutId: false,
 				isCWPDisabledIn3DView: false,
+				warningLevelBuffer: false,
 			},
 			{ autoBind: true },
 		);
@@ -835,13 +839,42 @@ export default class CWPStore {
 		this.taArrowClickedAircraftId = null;
 	}
 
+	/** Buffer a warning level message received before the role is known */
+	bufferWarningLevel(role: string, aircraftId: string, level: WarningLevel): void {
+		let roleBuffer = this.warningLevelBuffer.get(role);
+		if (!roleBuffer) {
+			roleBuffer = new Map();
+			this.warningLevelBuffer.set(role, roleBuffer);
+		}
+		roleBuffer.set(aircraftId, level);
+	}
+
+	/** Apply buffered warning levels for the given role and discard the buffer */
+	applyBufferedWarningLevels(role: string): void {
+		const buffer = this.warningLevelBuffer.get(role);
+		if (!buffer) return;
+		for (const [aircraftId, level] of buffer) {
+			this.setWarningLevel(aircraftId, level);
+		}
+		this.warningLevelBuffer.delete(role);
+	}
+
 	/** Get the warning level for an aircraft */
 	getWarningLevel(aircraftId: string): WarningLevel {
 		return this.aircraftWarningLevels.get(aircraftId) ?? "none";
 	}
 
-	/** Cycle to the next warning level: none → blue → orange → yellow → none */
-	cycleWarningLevel(aircraftId: string): void {
+	/** Set warning level directly, e.g. when received from MQTT sync */
+	setWarningLevel(aircraftId: string, level: WarningLevel): void {
+		if (level === "none") {
+			this.aircraftWarningLevels.delete(aircraftId);
+		} else {
+			this.aircraftWarningLevels.set(aircraftId, level);
+		}
+	}
+
+	/** Cycle to the next warning level: none → blue → orange → yellow → none. Returns the new level. */
+	cycleWarningLevel(aircraftId: string): WarningLevel {
 		const currentLevel = this.getWarningLevel(aircraftId);
 		const currentIndex = WARNING_LEVEL_ORDER.indexOf(currentLevel);
 		const nextIndex = (currentIndex + 1) % WARNING_LEVEL_ORDER.length;
@@ -852,6 +885,7 @@ export default class CWPStore {
 		} else {
 			this.aircraftWarningLevels.set(aircraftId, nextLevel);
 		}
+		return nextLevel;
 	}
 
 	/** Reset warning level to none */

--- a/src/model/CwpStore.ts
+++ b/src/model/CwpStore.ts
@@ -840,7 +840,11 @@ export default class CWPStore {
 	}
 
 	/** Buffer a warning level message received before the role is known */
-	bufferWarningLevel(role: string, aircraftId: string, level: WarningLevel): void {
+	bufferWarningLevel(
+		role: string,
+		aircraftId: string,
+		level: WarningLevel,
+	): void {
 		let roleBuffer = this.warningLevelBuffer.get(role);
 		if (!roleBuffer) {
 			roleBuffer = new Map();
@@ -852,7 +856,9 @@ export default class CWPStore {
 	/** Apply buffered warning levels for the given role and discard the buffer */
 	applyBufferedWarningLevels(role: string): void {
 		const buffer = this.warningLevelBuffer.get(role);
-		if (!buffer) return;
+		if (!buffer) {
+			return;
+		}
 		for (const [aircraftId, level] of buffer) {
 			this.setWarningLevel(aircraftId, level);
 		}

--- a/src/mqtt-client/publishers.ts
+++ b/src/mqtt-client/publishers.ts
@@ -301,6 +301,19 @@ export async function persistHiddenAircraft(
 	);
 }
 
+export async function persistWarningLevel(
+	flightUniqueId: string,
+	level: string,
+	role: string,
+): Promise<void> {
+	// Publishing an empty payload clears the retained message on the broker (level = "none")
+	await publish(
+		`frontend/${clientId}/cwp/${role}/flight/${flightUniqueId}/warningLevel`,
+		level === "none" ? "" : level,
+		{ retain: true },
+	);
+}
+
 /**
  * Publish manual AP override to MQTT as a retained message.
  * All instances sharing the same clientId will receive this and sync their AP mode.

--- a/src/mqtt-client/router.ts
+++ b/src/mqtt-client/router.ts
@@ -24,6 +24,7 @@ import {
 	frontendNextSectorFlightLevel,
 	frontendPredictiveTrajectoryState,
 	frontendSpeed,
+	frontendWarningLevel,
 	ignored,
 	initCompleted,
 	isaUpdate,
@@ -106,6 +107,8 @@ const router = rlite<Buffer>(notFound, {
 	"frontend/:clientId/flight/:flightId/localAssignedFL":
 		frontendLocalAssignedFlightLevel,
 	"frontend/:clientId/flight/:flightId/hidden": frontendFlightHidden,
+	"frontend/:clientId/cwp/:roleName/flight/:flightId/warningLevel":
+		frontendWarningLevel,
 	"frontend/:clientId/commands/force-refresh": frontendForceRefresh,
 	"ats/:clientId/status/presence/:sessionUuid": simulatorPresenceStatus,
 	"frontend/:clientId/brain/manualAP": frontendManualAP,

--- a/src/mqtt-client/subscribers.ts
+++ b/src/mqtt-client/subscribers.ts
@@ -46,6 +46,7 @@ import {
 	airwaysStore,
 	brainStore,
 	configurationStore,
+	cwpStore,
 	fixStore,
 	frequenciesStore,
 	roleConfigurationStore,
@@ -312,6 +313,28 @@ export function frontendFlightHidden(
 ): void {
 	const hidden = message.toString() === "true";
 	aircraftStore.handleFrontendFlightHidden(flightId, hidden);
+}
+
+export function frontendWarningLevel(
+	{ roleName, flightId }: { [key: string]: string },
+	message: Buffer,
+): void {
+	const raw = message.toString();
+	const level =
+		raw === "blue" || raw === "orange" || raw === "yellow"
+			? (raw as "blue" | "orange" | "yellow")
+			: "none";
+
+	const currentCWP = configurationStore.currentCWP;
+	if (!currentCWP) {
+		// Role not yet selected — buffer by role so only the right role's data is applied later
+		cwpStore.bufferWarningLevel(roleName, flightId, level);
+		return;
+	}
+	if (roleName !== currentCWP) {
+		return;
+	}
+	cwpStore.setWarningLevel(flightId, level);
 }
 
 export function flightConflictMessage(

--- a/src/state.ts
+++ b/src/state.ts
@@ -1,3 +1,4 @@
+import { reaction } from "mobx";
 import AdminStore from "./model/AdminStore";
 import AirblockStore from "./model/AirblockStore";
 import AircraftStore from "./model/AircraftStore";
@@ -74,6 +75,16 @@ export const sepQdmStore = new SepQdmStore({
 	configurationStore,
 	trajectoryPredictionStore,
 });
+
+// When the role is selected, apply any warning level messages that arrived before role selection
+reaction(
+	() => configurationStore.currentCWP,
+	(currentCWP) => {
+		if (currentCWP) {
+			cwpStore.applyBufferedWarningLevels(currentCWP);
+		}
+	},
+);
 
 configurationStore.setAircraftLeftVisibleAreaHandler((aircraftId) => {
 	cwpStore.removeAircraftUIState(aircraftId);


### PR DESCRIPTION
Yannick asked if the warning labels to be synced per role and I thought, oh well, that sounds easy. But there are several places you can change those warning labels.

I am too scared to just push it, would you be able to test this as well, please, if you will have the time? I will test more as well